### PR TITLE
Fix RUSTSEC-2020-0077 by replacing memmap with memmap2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ log = "0.4"
 
 [dev-dependencies]
 tempfile = "3.1"
-pretty_assertions = "0.6"
+pretty_assertions = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "segments"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["tekjar <raviteja@bytebeam.io>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -12,7 +12,7 @@ description = "kafka inspired rumqtt's mqtt commitlog"
 [dependencies]
 fnv = "1"
 byteorder = "1.3"
-memmap = "0.7"
+memmap2 = "0.5"
 log = "0.4"
 
 [dev-dependencies]

--- a/src/disk/index.rs
+++ b/src/disk/index.rs
@@ -1,5 +1,5 @@
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
-use memmap::MmapMut;
+use memmap2::MmapMut;
 use std::fs::{File, OpenOptions};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
This replaces the unmaintained memmap crate with the memmap2 crate in
order to fix the recurring security issue.

In order to get a new and shiny build with the updated dependency, we
have to bump the patch version of the package.

Some details here: https://github.com/danburkert/memmap-rs/issues/90

